### PR TITLE
numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 imageio[ffmpeg]
-numpy==1.23.5
+numpy==1.26.4
 roma
 gradio
 matplotlib


### PR DESCRIPTION
numpy 1.23.5 is not supported for python 3.12 (https://numpy.org/doc/2.1/release/1.23.5-notes.html). Upgrading to 1.26.4 solves the problem.